### PR TITLE
Tweak package.json lint script to lint add-on

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "devDependencies": {
     "addons-linter": "^0.15.14",
     "eslint": "^3.12.2",
-    "jpm": "^1.2.2"
+    "jpm": "^1.2.2",
+    "npm-run-all": "^4.0.0"
   },
   "engines": {
     "firefox": ">=50.0"
@@ -28,6 +29,8 @@
     "url": "git+https://github.com/mozilla/testpilot-containers.git"
   },
   "scripts": {
-    "lint": "eslint ."
+    "lint": "npm-run-all lint:*",
+    "lint:js": "eslint .",
+    "lint:addon": "addons-linter webextension --self-hosted"
   }
 }


### PR DESCRIPTION
Noticed we added a devDep for addons-linter, but it wasn't wired to anything.
Now running `npm run lint` will run both ESLint and the addons-linter tools.

If you want to run the scripts individually, you can still use stuff like `$ npm run lint:js -- --fix` to autofix any ESLint errors/warnings.