### PR TITLE
Add 'npm run once' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint .",
-    "lint:addon": "addons-linter webextension --self-hosted"
+    "lint:addon": "addons-linter webextension --self-hosted",
+    "once": "jpm run -b Aurora"
   }
 }


### PR DESCRIPTION
Add `$ npm run once` script which calls `jpm run` and launches an Aurora/DeveloperEdition browser with a fresh profile.

If you want to use a pre-built profile, just add `$ npm run once -- -p addon_dev`.