### PR TITLE
Add ESLint no-var and prefer-const rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,8 @@ module.exports = {
     "indent": ["error", 2],
     "linebreak-style": ["error", "unix"],
     "no-throw-literal": "error",
+    "no-var": "error",
+    "prefer-const": "error",
     "quotes": ["error", "double"],
     "radix": "error",
     "semi": ["error", "always"]

--- a/index.js
+++ b/index.js
@@ -18,13 +18,13 @@ const windowUtils = require("sdk/window/utils");
 
 const IDENTITY_COLORS = ["blue", "turquoise", "green", "yellow", "orange", "red", "pink", "purple"];
 
-let ContainerService = {
+const ContainerService = {
   _identitiesState: {},
 
   init() {
     // Enabling preferences
 
-    let prefs = [
+    const prefs = [
       [ "privacy.userContext.enabled", true ],
       [ "privacy.userContext.ui.enabled", true ],
       [ "privacy.usercontext.about_newtab_segregation.enabled", true ],
@@ -40,7 +40,7 @@ let ContainerService = {
 
     // only these methods are allowed. We have a 1:1 mapping between messages
     // and methods. These methods must return a promise.
-    let methods = [
+    const methods = [
       "hideTabs",
       "showTabs",
       "sortTabs",
@@ -64,7 +64,7 @@ let ContainerService = {
     });
 
     // It can happen that this jsm is loaded after the opening a container tab.
-    for (let tab of tabs) {
+    for (let tab of tabs) { // eslint-disable-line prefer-const
       const userContextId = this._getUserContextIdFromTab(tab);
       if (userContextId) {
         ++this._identitiesState[userContextId].openTabs;
@@ -87,7 +87,7 @@ let ContainerService = {
 
     // Modify CSS and other stuff for each window.
 
-    for (let window of windows.browserWindows) {
+    for (let window of windows.browserWindows) { // eslint-disable-line prefer-const
       this.configureWindow(viewFor(window));
     }
 
@@ -159,10 +159,10 @@ let ContainerService = {
   },
 
   _getTabList(userContextId) {
-    let list = [];
-    for (let tab of tabs) {
+    const list = [];
+    for (let tab of tabs) { // eslint-disable-line prefer-const
       if (userContextId === this._getUserContextIdFromTab(tab)) {
-        let object = { title: tab.title, url: tab.url, id: tab.id };
+        const object = { title: tab.title, url: tab.url, id: tab.id };
         list.push(object);
       }
     }
@@ -179,7 +179,7 @@ let ContainerService = {
         return;
       }
 
-      for (let tab of tabs) {
+      for (let tab of tabs) { // eslint-disable-line prefer-const
         if (args.userContextId !== this._getUserContextIdFromTab(tab)) {
           continue;
         }
@@ -198,9 +198,9 @@ let ContainerService = {
       return;
     }
 
-    let promises = [];
+    const promises = [];
 
-    for (let url of this._identitiesState[args.userContextId].hiddenTabUrls) {
+    for (let url of this._identitiesState[args.userContextId].hiddenTabUrls) { // eslint-disable-line prefer-const
       promises.push(this.openTab({ userContextId: args.userContextId, url }));
     }
 
@@ -211,7 +211,7 @@ let ContainerService = {
 
   sortTabs() {
     return new Promise(resolve => {
-      for (let window of windows.browserWindows) {
+      for (let window of windows.browserWindows) { // eslint-disable-line prefer-const
         // First the pinned tabs, then the normal ones.
         this._sortTabsInternal(window, true);
         this._sortTabsInternal(window, false);
@@ -228,8 +228,8 @@ let ContainerService = {
     let pos = 0;
 
     // Let's collect UCIs/tabs for this window.
-    let map = new Map;
-    for (let tab of tabs) {
+    const map = new Map;
+    for (let tab of tabs) { // eslint-disable-line prefer-const
       if (pinnedTabs && !tabsUtils.isPinned(tab)) {
         // We don't have, or we already handled all the pinned tabs.
         break;
@@ -253,7 +253,7 @@ let ContainerService = {
 
     // Let's move tabs.
     sortMap.forEach(tabs => {
-      for (let tab of tabs) {
+      for (let tab of tabs) { // eslint-disable-line prefer-const
         xulWindow.gBrowser.moveTabTo(tab, pos++);
       }
     });
@@ -267,9 +267,9 @@ let ContainerService = {
       }
 
       const list = this._getTabList(args.userContextId);
-      let promises = [];
+      const promises = [];
 
-      for (let object of list) {
+      for (let object of list) { // eslint-disable-line prefer-const
         promises.push(getFavicon(object.url).then(url => {
           object.favicon = url;
         }, () => {
@@ -290,7 +290,7 @@ let ContainerService = {
         return;
       }
 
-      for (let tab of tabs) {
+      for (let tab of tabs) { // eslint-disable-line prefer-const
         if (tab.id === args.tabId) {
           tab.window.activate();
           tab.activate();
@@ -309,7 +309,7 @@ let ContainerService = {
         return;
       }
 
-      // Let"s create a list of the tabs.
+      // Let's create a list of the tabs.
       const list = this._getTabList(args.userContextId);
 
       // Nothing to do
@@ -324,7 +324,7 @@ let ContainerService = {
           const newBrowserWindow = viewFor(window);
 
           // Let's move the tab to the new window.
-          for (let tab of list) {
+          for (let tab of list) { // eslint-disable-line prefer-const
             const newTab = newBrowserWindow.gBrowser.addTab("about:blank");
             newBrowserWindow.gBrowser.swapBrowsersAndCloseOther(newTab, tab);
             // swapBrowsersAndCloseOther is an internal method of gBrowser
@@ -337,7 +337,7 @@ let ContainerService = {
           // Let's close all the normal tab in the new window. In theory it
           // should be only the first tab, but maybe there are addons doing
           // crazy stuff.
-          for (let tab of window.tabs) {
+          for (let tab of window.tabs) { // eslint-disable-line prefer-const
             const userContextId = this._getUserContextIdFromTab(tab);
             if (args.userContextId !== userContextId) {
               newBrowserWindow.gBrowser.removeTab(viewFor(tab));
@@ -351,7 +351,7 @@ let ContainerService = {
 
   openTab(args) {
     return new Promise(resolve => {
-      let browserWin = windowUtils.getMostRecentBrowserWindow();
+      const browserWin = windowUtils.getMostRecentBrowserWindow();
 
       // This should not really happen.
       if (!browserWin || !browserWin.gBrowser) {
@@ -363,7 +363,7 @@ let ContainerService = {
         userContextId = args.userContextId;
       }
 
-      let tab = browserWin.gBrowser.addTab(args.url || null, { userContextId });
+      const tab = browserWin.gBrowser.addTab(args.url || null, { userContextId });
       browserWin.gBrowser.selectedTab = tab;
       resolve(true);
     });
@@ -373,10 +373,10 @@ let ContainerService = {
 
   queryIdentities() {
     return new Promise(resolve => {
-      let identities = [];
+      const identities = [];
 
       ContextualIdentityService.getIdentities().forEach(identity => {
-        let convertedIdentity = this._convert(identity);
+        const convertedIdentity = this._convert(identity);
         identities.push(convertedIdentity);
       });
 
@@ -390,12 +390,12 @@ let ContainerService = {
       return;
     }
 
-    let identity = ContextualIdentityService.getIdentityFromId(args.userContextId);
+    const identity = ContextualIdentityService.getIdentityFromId(args.userContextId);
     return Promise.resolve(identity ? this._convert(identity) : null);
   },
 
   createIdentity(args) {
-    for (let arg of [ "name", "color", "icon"]) {
+    for (let arg of [ "name", "color", "icon"]) { // eslint-disable-line prefer-const
       if (!(arg in args)) {
         Promise.reject("createIdentity must be called with " + arg + " argument.");
         return;
@@ -419,8 +419,8 @@ let ContainerService = {
       return;
     }
 
-    let identity = ContextualIdentityService.getIdentityFromId(args.userContextId);
-    for (let arg of [ "name", "color", "icon"]) {
+    const identity = ContextualIdentityService.getIdentityFromId(args.userContextId);
+    for (let arg of [ "name", "color", "icon"]) { // eslint-disable-line prefer-const
       if ((arg in args)) {
         identity[arg] = args[arg];
       }
@@ -445,15 +445,15 @@ let ContainerService = {
   // Styling the window
 
   configureWindow(window) {
-    var tabsElement = window.document.getElementById("tabbrowser-tabs");
-    var button = window.document.getAnonymousElementByAttribute(tabsElement, "anonid", "tabs-newtab-button");
+    const tabsElement = window.document.getElementById("tabbrowser-tabs");
+    const button = window.document.getAnonymousElementByAttribute(tabsElement, "anonid", "tabs-newtab-button");
 
     while (button.firstChild) {
       button.removeChild(button.firstChild);
     }
 
     button.setAttribute("type", "menu");
-    let popup = window.document.createElementNS(XUL_NS, "menupopup");
+    const popup = window.document.createElementNS(XUL_NS, "menupopup");
 
     popup.setAttribute("anonid", "newtab-popup");
     popup.className = "new-tab-popup";
@@ -462,7 +462,7 @@ let ContainerService = {
     ContextualIdentityService.getIdentities().forEach(identity => {
       identity = this._convert(identity);
 
-      var menuItem = window.document.createElementNS(XUL_NS, "menuitem");
+      const menuItem = window.document.createElementNS(XUL_NS, "menuitem");
       menuItem.setAttribute("class", "menuitem-iconic");
       menuItem.setAttribute("label", identity.name);
       menuItem.setAttribute("image", self.data.url("usercontext.svg") + "#" + identity.image);
@@ -476,7 +476,7 @@ let ContainerService = {
     });
 
     button.appendChild(popup);
-    let style = Style({ uri: self.data.url("chrome.css") });
+    const style = Style({ uri: self.data.url("chrome.css") });
 
     attachTo(style, viewFor(window));
   }

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -1,4 +1,4 @@
-var main = require("../");
+const main = require("../");
 
 exports["test main"] = function(assert) {
   assert.pass("Unit test running!");

--- a/webextension/js/popup.js
+++ b/webextension/js/popup.js
@@ -24,7 +24,7 @@ function log(...args) {
 }
 
 // This object controls all the panels, identities and many other things.
-let Logic = {
+const Logic = {
   _identities: [],
   _currentIdentity: null,
   _currentPanel: null,
@@ -69,7 +69,7 @@ let Logic = {
 
     // Initialize the panel before showing it.
     this._panels[panel].prepare().then(() => {
-      for (let panelElement of document.querySelectorAll(".panel")) {
+      for (let panelElement of document.querySelectorAll(".panel")) { // eslint-disable-line prefer-const
         panelElement.classList.add("hide");
       }
       document.querySelector(this._panels[panel].panelSelector).classList.remove("hide");
@@ -102,12 +102,12 @@ let Logic = {
 
   generateIdentityName() {
     const defaultName = "Container";
-    let ids = [];
+    const ids = [];
 
     // This loop populates the 'ids' array with all the already-used ids.
     this._identities.forEach(identity => {
       if (identity.name.startsWith(defaultName)) {
-        let id = parseInt(identity.name.substr(defaultName.length), 10);
+        const id = parseInt(identity.name.substr(defaultName.length), 10);
         if (id) {
           ids.push(id);
         }
@@ -192,11 +192,11 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
 
   // This method is called when the panel is shown.
   prepare() {
-    let fragment = document.createDocumentFragment();
+    const fragment = document.createDocumentFragment();
 
     Logic.identities().forEach(identity => {
       log("identities.forEach");
-      let tr = document.createElement("tr");
+      const tr = document.createElement("tr");
       fragment.appendChild(tr);
       tr.classList.add("container-panel-row", "clickable");
       tr.innerHTML = `
@@ -228,7 +228,7 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
       });
     });
 
-    let list = document.querySelector(".identities-list");
+    const list = document.querySelector(".identities-list");
 
     list.innerHTML = "";
     list.appendChild(fragment);
@@ -250,7 +250,7 @@ Logic.registerPanel(P_CONTAINER_INFO, {
     });
 
     document.querySelector("#container-info-hideorshow").addEventListener("click", () => {
-      let identity = Logic.currentIdentity();
+      const identity = Logic.currentIdentity();
       browser.runtime.sendMessage({
         method: identity.hasHiddenTabs ? "showTabs" : "hideTabs",
         userContextId: identity.userContextId
@@ -271,17 +271,17 @@ Logic.registerPanel(P_CONTAINER_INFO, {
 
   // This method is called when the panel is shown.
   prepare() {
-    let identity = Logic.currentIdentity();
+    const identity = Logic.currentIdentity();
 
     // Populating the panel: name and icon
     document.getElementById("container-info-name").innerText = identity.name;
 
-    let icon = document.getElementById("container-info-icon");
+    const icon = document.getElementById("container-info-icon");
     icon.setAttribute("data-identity-icon", identity.image);
     icon.setAttribute("data-identity-color", identity.color);
 
     // Show or not the has-tabs section.
-    for (let trHasTabs of document.getElementsByClassName("container-info-has-tabs")) {
+    for (let trHasTabs of document.getElementsByClassName("container-info-has-tabs")) { // eslint-disable-line prefer-const
       trHasTabs.hidden = !identity.hasHiddenTabs && !identity.hasOpenTabs;
     }
 
@@ -292,7 +292,7 @@ Logic.registerPanel(P_CONTAINER_INFO, {
     hideShowLabel.innerText = identity.hasHiddenTabs ? "Show these container tabs" : "Hide these container tabs";
 
     // Let's remove all the previous tabs.
-    for (let trTab of document.getElementsByClassName("container-info-tab")) {
+    for (let trTab of document.getElementsByClassName("container-info-tab")) { // eslint-disable-line prefer-const
       trTab.remove();
     }
 
@@ -303,9 +303,9 @@ Logic.registerPanel(P_CONTAINER_INFO, {
     }).then(tabs => {
       log("browser.runtime.sendMessage getTabs, tabs: ", tabs);
       // For each one, let's create a new line.
-      let fragment = document.createDocumentFragment();
-      for (let tab of tabs) {
-        let tr = document.createElement("tr");
+      const fragment = document.createDocumentFragment();
+      for (let tab of tabs) { // eslint-disable-line prefer-const
+        const tr = document.createElement("tr");
         fragment.appendChild(tr);
         tr.classList.add("container-info-tab", "clickable");
         tr.innerHTML = `
@@ -346,9 +346,9 @@ Logic.registerPanel(P_CONTAINERS_EDIT, {
 
   // This method is called when the panel is shown.
   prepare() {
-    let fragment = document.createDocumentFragment();
+    const fragment = document.createDocumentFragment();
     Logic.identities().forEach(identity => {
-      let tr = document.createElement("tr");
+      const tr = document.createElement("tr");
       fragment.appendChild(tr);
       tr.innerHTML = `
         <td>
@@ -381,7 +381,7 @@ Logic.registerPanel(P_CONTAINERS_EDIT, {
       });
     });
 
-    let list = document.querySelector("#edit-identities-list");
+    const list = document.querySelector("#edit-identities-list");
 
     list.innerHTML = "";
     list.appendChild(fragment);
@@ -407,7 +407,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
     });
 
     document.querySelector("#edit-container-ok-link").addEventListener("click", () => {
-      let identity = Logic.currentIdentity();
+      const identity = Logic.currentIdentity();
       browser.runtime.sendMessage({
         method: identity.userContextId ? "updateIdentity" : "createIdentity",
         userContextId: identity.userContextId || 0,
@@ -424,7 +424,7 @@ Logic.registerPanel(P_CONTAINER_EDIT, {
 
   // This method is called when the panel is shown.
   prepare() {
-    let identity = Logic.currentIdentity();
+    const identity = Logic.currentIdentity();
     document.querySelector("#edit-container-panel-name-input").value = identity.name || "";
 
     // FIXME: color and icon must be set. But we need the UI first.
@@ -459,12 +459,12 @@ Logic.registerPanel(P_CONTAINER_DELETE, {
 
   // This method is called when the panel is shown.
   prepare() {
-    let identity = Logic.currentIdentity();
+    const identity = Logic.currentIdentity();
 
     // Populating the panel: name and icon
     document.getElementById("delete-container-name").innerText = identity.name;
 
-    let icon = document.getElementById("delete-container-icon");
+    const icon = document.getElementById("delete-container-icon");
     icon.setAttribute("data-identity-icon", identity.image);
     icon.setAttribute("data-identity-color", identity.color);
 


### PR DESCRIPTION
Not 100% on the `prefer-const` rule, since I think [Firefox has a bug (1094995)](https://bugzilla.mozilla.org/show_bug.cgi?id=1094995) with `const` and `for..of` loops, so when using `for..of`, I had to inline disable that rule for that line.

For more information, see https://github.com/eslint/eslint/issues/3104
