### PR TITLE
fix #141: container-name class truncate long names

### DIFF
--- a/webextension/css/popup.css
+++ b/webextension/css/popup.css
@@ -162,6 +162,13 @@ table.unstriped tbody tr {
   color: #0a0a0a;
 }
 
+.container-name {
+  max-inline-size: 7em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .edit-container-panel [type="radio"] {
   display: inline;
   margin-inline-start: -17px;

--- a/webextension/js/popup.js
+++ b/webextension/js/popup.js
@@ -234,7 +234,7 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
             data-identity-color="${identity.color}">
           </div>
         </td>
-        <td class="open-newtab">${identity.name}</td>
+        <td class="open-newtab container-name">${identity.name}</td>
         <td class="show-tabs"><img src="/img/container-arrow.svg" class="show-tabs ${arrowClass}" /></td>`;
 
       tr.addEventListener("click", e => {
@@ -397,7 +397,7 @@ Logic.registerPanel(P_CONTAINERS_EDIT, {
             data-identity-color="${identity.color}">
           </div>
         </td>
-        <td>${identity.name}</td>
+        <td class="container-name">${identity.name}</td>
         <td class="edit-container">
           <img
             title="Edit ${identity.name} container"

--- a/webextension/popup.html
+++ b/webextension/popup.html
@@ -68,7 +68,7 @@
       <div class="small-10 columns">
         <div class="row container-info-panel-header">
           <span class="usercontext-icon" id="container-info-icon"></span>
-          <h3 id="container-info-name" class="panel-header-text"></h3>
+          <h3 id="container-info-name" class="panel-header-text container-name"></h3>
         </div>
         <div class="row container-info-panel-hide container-info-has-tabs clickable" id="container-info-hideorshow">
           <img id="container-info-hideorshow-icon" alt="Hide Container icon" src="/img/container-hide.svg" class="icon container-info-panel-hideorshow-icon"/><span id="container-info-hideorshow-label">Hide this container</span><br/>
@@ -144,7 +144,7 @@
       <div class="small-12 columns">
         <div class="row container-info-panel-header">
           <span class="usercontext-icon" id="delete-container-icon"></span>
-          <h3 id="delete-container-name" class="panel-header-text"></h3>
+          <h3 id="delete-container-name" class="panel-header-text container-name"></h3>
         </div>
         <div class="row delete-container-confirm">
           <h4 class="delete-container-confirm-title">Remove This Container</h4>


### PR DESCRIPTION
![containers-truncate](https://cloud.githubusercontent.com/assets/71928/22568755/9ef5358c-e95a-11e6-98d1-aea209fa59e8.png)

![container-tabs-truncate](https://cloud.githubusercontent.com/assets/71928/22568758/a20116a6-e95a-11e6-8a6d-41e672a37eed.png)

![containers-edit-truncate](https://cloud.githubusercontent.com/assets/71928/22568762/a4be9b02-e95a-11e6-9ba8-cd0508100237.png)

![container-delete-truncate](https://cloud.githubusercontent.com/assets/71928/22568765/a70a8538-e95a-11e6-8ad1-3c6c8733111f.png)