### PR TITLE
fix #142: disable arrow if container has no tabs

### DIFF
--- a/webextension/css/popup.css
+++ b/webextension/css/popup.css
@@ -274,6 +274,12 @@ table.unstriped tbody tr {
   --identity-icon: url("/img/usercontext.svg#circle");
 }
 
+.no-tabs-img {
+  block-size: 12px;
+  filter: opacity(30%);
+  inline-size: 12px;
+}
+
 .show-tabs-img {
   block-size: 12px;
   inline-size: 12px;

--- a/webextension/js/popup.js
+++ b/webextension/js/popup.js
@@ -222,6 +222,8 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
     const fragment = document.createDocumentFragment();
 
     Logic.identities().forEach(identity => {
+      const hasTabs = (identity.hasHiddenTabs || identity.hasOpenTabs);
+      const arrowClass = hasTabs ? "show-tabs-img" : "no-tabs-img";
       const tr = document.createElement("tr");
       fragment.appendChild(tr);
       tr.classList.add("container-panel-row", "clickable");
@@ -233,7 +235,7 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
           </div>
         </td>
         <td class="open-newtab">${identity.name}</td>
-        <td class="show-tabs"><img src="/img/container-arrow.svg" class="show-tabs show-tabs-img" /></td>`;
+        <td class="show-tabs"><img src="/img/container-arrow.svg" class="show-tabs ${arrowClass}" /></td>`;
 
       tr.addEventListener("click", e => {
         if (e.target.matches(".open-newtab")) {
@@ -250,7 +252,7 @@ Logic.registerPanel(P_CONTAINERS_LIST, {
           }).catch(() => {
             window.close();
           });
-        } else if (e.target.matches(".show-tabs")) {
+        } else if (hasTabs && e.target.matches(".show-tabs")) {
           Logic.showPanel(P_CONTAINER_INFO, identity);
         }
       });


### PR DESCRIPTION
<img width="819" alt="empty-containers" src="https://cloud.githubusercontent.com/assets/71928/22610156/b893d460-ea29-11e6-9f6b-2f945955b51f.png">
