### PR TITLE
for #242: disable move when incompatible add-ons detected

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,12 @@ const DEFAULT_TAB = "about:newtab";
 const SHOW_MENU_TIMEOUT = 100;
 const HIDE_MENU_TIMEOUT = 300;
 
+const INCOMPATIBLE_ADDON_IDS = [
+  "pulse@mozilla.com",
+  "snoozetabs@mozilla.com",
+  "jid1-NeEaf3sAHdKHPA@jetpack" // PageShot
+];
+
 const IDENTITY_COLORS = [
  { name: "blue", color: "#00a7e0" },
  { name: "turquoise", color: "#01bdad" },
@@ -40,6 +46,7 @@ const PREFS = [
   [ "privacy.usercontext.about_newtab_segregation.enabled", true ],
 ];
 
+const { AddonManager } = require("resource://gre/modules/AddonManager.jsm");
 const { attachTo, detachFrom } = require("sdk/content/mod");
 const { Cu } = require("chrome");
 const { ContextualIdentityService } = require("resource://gre/modules/ContextualIdentityService.jsm");
@@ -181,7 +188,8 @@ const ContainerService = {
       "removeIdentity",
       "updateIdentity",
       "getPreference",
-      "sendTelemetryPayload"
+      "sendTelemetryPayload",
+      "checkIncompatibleAddons"
     ];
 
     // Map of identities.
@@ -486,6 +494,15 @@ const ContainerService = {
     Object.assign(payload, args);
 
     this._sendEvent(payload);
+  },
+
+  checkIncompatibleAddons() {
+    return new Promise(resolve => {
+      AddonManager.getAddonsByIDs(INCOMPATIBLE_ADDON_IDS, (addons) => {
+        addons = addons.filter((a) => a && a.isActive);
+        resolve(addons.length !== 0);
+      });
+    });
   },
 
   // Tabs management

--- a/webextension/css/popup.css
+++ b/webextension/css/popup.css
@@ -420,7 +420,13 @@ span ~ .panel-header-text {
   margin-block-start: 4px;
 }
 
-.container-info-tab-row:not(.clickable) {
+#container-info-movetabs-incompat {
+  font-size: 10px;
+  opacity: 0.3;
+}
+
+.container-info-tab-row:not(.clickable),
+.select-row:not(.clickable) {
   opacity: 0.3;
 }
 


### PR DESCRIPTION
I dislike almost everything about this patch/PR, but we want to disable the move feature when we detect incompatible add-ons. There's a hover tooltip, but [bug 1269421](https://bugzilla.mozilla.org/show_bug.cgi?id=1269421) means I had to also add a message in the pop-up itself ...

![txp-containers-move-incompat](https://cloud.githubusercontent.com/assets/71928/23372482/741af636-fce1-11e6-9b4c-a825394c9cfc.png)

To verify/test ...

1. Install Pulse (or PageShot) addons (via Test Pilot add-on or manually)
2. Install Containers addon
3. Create a container tab
4. Open the "container tabs" panel
5. [ ] Verify "Move tabs" is disabled with an appropriate message
6. Un-install or disable pulse (or PageShot) addon(s)
7. Open the "container tabs" panel again
8. [ ] Verify "Move tabs" is re-enabled