### PR TITLE
fix #272: add event telemetry for incompat addons

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -169,6 +169,15 @@ of a `testpilottest` telemetry ping for each scenario.
   }
 ```
 
+* When a user encounters the disabled "move" feature because of incompatible add-ons
+
+```js
+  {
+    "uuid": <uuid>,
+    "event": "incompatible-addons-detected"
+  }
+```
+
 ### A Redshift schema for the payload:
 
 ```lua

--- a/index.js
+++ b/index.js
@@ -500,7 +500,13 @@ const ContainerService = {
     return new Promise(resolve => {
       AddonManager.getAddonsByIDs(INCOMPATIBLE_ADDON_IDS, (addons) => {
         addons = addons.filter((a) => a && a.isActive);
-        resolve(addons.length !== 0);
+        const incompatibleAddons = addons.length !== 0;
+        if (incompatibleAddons) {
+          this.sendTelemetryPayload({
+            "event": "incompatible-addons-detected"
+          });
+        }
+        resolve(incompatibleAddons);
       });
     });
   },


### PR DESCRIPTION
This adds a Telemetry ping when users encounter the "Incompatible addons" message in the containers pop-up. The ping is sent with `uuid` so we will be able to group the pings to know *how many users* are seeing the message - not just the raw counts of how many times it's shown.

To verify:

1. Install Test Pilot add-on (required to create Telemetry channel)
2. Install Pulse (or PageShot) experiment(s)
3. Install Containers experiment
4. Open a container tab
5. Open the pageAction popup
6. Click the container
7. [ ] Verify you see the "incompatible with experiments" message on the disabled move action
8. Go to `about:telemetry`, "Archived ping data" ...

![txp-about-telemetry](https://cloud.githubusercontent.com/assets/71928/23381233/54cbd5ee-fd03-11e6-8dc0-486e1d533aa7.png)

* [ ] Verify the latest "Raw payload" of the ping data is the "incompatible-addons-detected" ping.