### PR TITLE
Removing tabcenter css

### DIFF
--- a/data/usercontext.css
+++ b/data/usercontext.css
@@ -1,5 +1,5 @@
 /* HACK: Custom Container vars do not propigate correctly
-until the container tab is blurred and refocused, 
+until the container tab is blurred and refocused,
 adding the data-identity-color with the default hex
 value, or chrome url path as an alternate selector mitiages this bug.*/
 [data-identity-color="blue"],
@@ -188,18 +188,6 @@ special cases are addressed below */
 .tabbrowser-tab[usercontextid][pinned="true"] .tab-background-middle::after {
   left: -150%;
   width: 400%;
-}
-
-/* this fixes containers tab center */
-#verticaltabs-box .tabbrowser-tab[usercontextid] .tab-content::after {
-  background-color: var(--identity-tab-color);
-  content: '';
-  height: 100% !important;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 3px !important;
-  z-index: 999;
 }
 
 .tabs-newtab-button .toolbarbutton-icon[type="menu"] {


### PR DESCRIPTION
As stated by @fvsch on #354, **Containers** doesn't need the **Tab Center** centric CSS to have compatibility. The PR is simply to remove the segment to move along the compatibility.