### PR TITLE
for #321: page count telemetry per activity

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -189,6 +189,17 @@ of a `testpilottest` telemetry ping for each scenario.
   }
 ```
 
+* The user goes idle
+
+```js
+  {
+    "uuid": <uuid>,
+    "userContextId": <userContextId>,
+    "event": "page-requests-completed-per-activity",
+    "pageRequestCount": <pageRequestCount>
+  }
+```
+
 * The user chooses "Always Open in this Container" context menu option. (Note: We send two separate event names: one for assigning a site to a container, one for removing a site from a container.)
 
 ```js

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -24,6 +24,7 @@
     "cookies",
     "contextMenus",
     "history",
+    "idle",
     "notifications",
     "storage",
     "tabs",


### PR DESCRIPTION
Adds a new `page-requests-completed-per-activity` event ping with `pageRequestCount` metric. Note: these pings are in addition to the `-per-tab` pings, so we will analyze them separately.

Steps to verify:
* Create some (non-container and/or container) tabs
* Make some page loads in some of the tabs
* Leave your computer idle for ~60s (don't close any of the tabs)
* Go to about:telemetry
  * Check "archived ping data"
  * The payload drop down should contain "*-testpilottest" options - pick some
  * Verify they have the expected `page-requests-completed-per-activity` event string, and the proper `userContextId` and `pageRequestCount` values
* Make some more page loads in the still-open tabs
* Go to about:telemetry
  * Check "archived ping data"
  * The payload drop down should contain "*-testpilottest" options - pick some
  * Verify they have the expected `page-requests-completed-per-tab` event string, and the proper `userContextId` and `pageRequestCount` values