### PR TITLE
for #511: add "same-container" telemetry ping

### DIFF
--- a/webextension/js/confirm-page.js
+++ b/webextension/js/confirm-page.js
@@ -63,6 +63,10 @@ async function denySubmit(redirectUrl) {
     tabId: tab[0].id,
     pageUrl: redirectUrl
   });
+  browser.runtime.sendMessage({
+    method: "sendTelemetryPayload",
+    event: "click-to-reload-page-in-same-container",
+  });
   document.location.replace(redirectUrl);
 }
 


### PR DESCRIPTION
May not need to merge ... ?

When I stepped thru the "Open in Current Container" flow, I didn't see a `click-to-reload-page-in-same-container` telemetry ping sent.

So, I added it to the `denySubmit` function.

However, there's code to send the ping in `openInContainer`, but that never seems to run?

I'm confused. 😢 