### PR TITLE
Fix on update icons being reset to central defaults. Fixes #703

### DIFF
--- a/index.js
+++ b/index.js
@@ -1028,6 +1028,8 @@ const ContainerService = {
       // Let's forget all the previous closed tabs.
       this._forgetIdentity();
 
+      this._resetContainerToCentralIcons();
+
       const preInstalledIdentities = data.preInstalledIdentities;
       ContextualIdentityProxy.getIdentities().forEach(identity => {
         if (!preInstalledIdentities.includes(identity.userContextId)) {
@@ -1326,8 +1328,6 @@ ContainerWindow.prototype = {
     this._shutdownFileMenu();
     this._shutdownAllTabsMenu();
     this._shutdownContextMenu();
-
-    this._shutdownContainers();
   },
 
   _shutDownPlusButtonMenuElement(buttonElement) {
@@ -1390,7 +1390,7 @@ ContainerWindow.prototype = {
     return true;
   },
 
-  _shutdownContainers() {
+  _resetContainerToCentralIcons() {
     ContextualIdentityProxy.getIdentities().forEach(identity => {
       if (IDENTITY_ICONS_STANDARD.indexOf(identity.icon) !== -1 &&
           IDENTITY_COLORS_STANDARD.indexOf(identity.color) !== -1) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testpilot-containers",
   "title": "Containers Experiment",
   "description": "Containers works by isolating cookie jars using separate origin-attributes defined visually by colored ‘Container Tabs’. This add-on is a modified version of the containers feature for Firefox Test Pilot.",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "author": "Andrea Marchesini, Luke Crouch and Jonathan Kingston",
   "bugs": {
     "url": "https://github.com/mozilla/testpilot-containers/issues"

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Containers Experiment",
-  "version": "2.4.1",
+  "version": "2.5.0",
 
   "description": "Containers works by isolating cookie jars using separate origin-attributes defined visually by colored ‘Container Tabs’. This add-on is a modified version of the containers feature for Firefox Test Pilot.",
   "icons": {


### PR DESCRIPTION
@groovecoder let me know when this is merged and I can rebase it into my other patch (I would like to land that this week, I still can't replicate on Nightly at leasr the issue you had).