### PR TITLE
remove updateURL so Test Pilot users go to AMO

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -15,7 +15,7 @@
         <em:maxVersion>*</em:maxVersion>
       </Description>
     </em:targetApplication>
-    <em:version>3.1.0</em:version>
+    <em:version>3.1.1</em:version>
     <em:unpack>false</em:unpack>
   </Description>
 </RDF>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testpilot-containers",
   "title": "Containers Experiment",
   "description": "Containers works by isolating cookie jars using separate origin-attributes defined visually by colored ‘Container Tabs’. This add-on is a modified version of the containers feature for Firefox Test Pilot.",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": "Andrea Marchesini, Luke Crouch and Jonathan Kingston",
   "bugs": {
     "url": "https://github.com/mozilla/testpilot-containers/issues"
@@ -39,6 +39,5 @@
     "lint:js": "eslint .",
     "package": "npm run build && mv testpilot-containers.xpi addon.xpi",
     "test": "npm run lint"
-  },
-  "updateURL": "https://testpilot.firefox.com/files/@testpilot-containers/updates.json"
+  }
 }

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Containers Experiment",
-  "version": "3.1.0",
+  "version": "3.1.1",
 
   "description": "Containers works by isolating cookie jars using separate origin-attributes defined visually by colored ‘Container Tabs’. This add-on is a modified version of the containers feature for Firefox Test Pilot.",
   "icons": {
@@ -11,12 +11,11 @@
 
   "applications": {
     "gecko": {
-      "strict_min_version": "51.0",
-      "update_url": "https://testpilot.firefox.com/files/@testpilot-containers/updates.json"
+      "strict_min_version": "51.0"
     }
   },
 
-  "homepage_url": "https://testpilot.firefox.com/",
+  "homepage_url": "https://addons.mozilla.org/firefox/addon/multi-account-containers/",
 
   "permissions": [
     "<all_urls>",


### PR DESCRIPTION
Merge 3.1.1 with deleted `updateURL`. This should push any remaining Test Pilot 3.x over to 4.x from AMO.

If it doesn't, we can try a 3.1.2 that explicitly sets the `updateURL` to an update manifest URL on AMO.